### PR TITLE
Fix issue #7. Now only one rspacer tag is added.

### DIFF
--- a/R/documents.R
+++ b/R/documents.R
@@ -28,7 +28,7 @@ document_post <- function(body, api_key = get_api_key()) {
 }
 
 document_replace <- function(body, existing_document_id, api_key = get_api_key()) {
-  body$tags <- paste0(c("rspacer", body$tags), collapse= ",")
+  ifelse("rspacer" %in% stringr::str_split_1(body$tags, ","), body$tags, paste0(c("rspacer", body$tags), collapse= ","))
   request() |>
     httr2::req_url_path_append("documents", parse_rspace_id(existing_document_id)) |>
     httr2::req_headers(`apiKey` = api_key) |>


### PR DESCRIPTION
When replacing a file, we do want to add the rspacer tag, but not if it was already present. 